### PR TITLE
GDAL python bindings

### DIFF
--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -215,8 +215,7 @@ COPY --from=tiff ${STAGING_DIR}/usr/local /usr/local
 COPY --from=proj ${STAGING_DIR}/usr/local /usr/local
 
 # install
-RUN mkdir -p "./source" "./build"; \
-    #
+RUN \
     # download & unzip
     TAR_FILE="libgeotiff-${GEOTIFF_VERSION}.tar.gz"; \
     curl -fsSLO "https://download.osgeo.org/geotiff/libgeotiff/${TAR_FILE}"; \
@@ -237,12 +236,13 @@ RUN mkdir -p "./source" "./build"; \
 
 
 # -----------------------------------------------------------------------------
-# GDAL (final image)
+# GDAL setup for build
 # -----------------------------------------------------------------------------
-FROM base
+FROM base as setup
 
 # version argument
 ARG GDAL_VERSION=3.3.3
+ENV GDAL_VERSION=$GDAL_VERSION
 
 # additional build dependencies
 RUN yum install -y \
@@ -252,9 +252,21 @@ RUN yum install -y \
       zlib-devel; \
     yum clean all
 
+# download & unzip
+RUN TAR_FILE="gdal-${GDAL_VERSION}.tar.gz"; \
+    curl -fsSLO "https://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE}"; \
+    tar -xf "${TAR_FILE}" --strip-components=1; \
+    rm "${TAR_FILE}"
+
+
+# -----------------------------------------------------------------------------
+# GDAL build library
+# -----------------------------------------------------------------------------
+FROM setup as library
+
 # local dependencies to staging directory
-# the base has many other dependencies already in /usr/local,
-# so we isolate packages in a staging directory
+# base manylinux image has many other dependencies already in /usr/local,
+# so we isolate packages in the staging directory
 COPY --from=openjpeg ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=ecw ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=tiff ${STAGING_DIR} ${STAGING_DIR}
@@ -270,20 +282,10 @@ COPY --from=openjpeg ${STAGING_DIR}/usr/local /usr/local
 # add staged libraries
 ENV LD_LIBRARY_PATH="${STAGING_DIR}/usr/local/lib"
 
-# Patch file for downstream image
-ENV GDAL_PATCH_FILE=${STAGING_DIR}/usr/local/share/just/container_build_patch/30_gdal
-ADD 30_gdal ${GDAL_PATCH_FILE}
-RUN chmod +x ${GDAL_PATCH_FILE}
-
-# install
+# configure, build, & install
+# https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/configure
 RUN \
-    # download & unzip
-    TAR_FILE="gdal-${GDAL_VERSION}.tar.gz"; \
-    curl -fsSLO "https://download.osgeo.org/gdal/${GDAL_VERSION}/${TAR_FILE}"; \
-    tar -xf "${TAR_FILE}" --strip-components=1; \
-    #
-    # configure, build, & install
-    # https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/configure
+    # configure
     ./configure \
         --without-libtool \
         --with-hide-internal-symbols \
@@ -305,6 +307,74 @@ RUN \
     # cleanup
     rm -rf /tmp/*;
 
+
+# -----------------------------------------------------------------------------
+# GDAL build wheel
+# -----------------------------------------------------------------------------
+FROM setup as wheel
+
+# version argument
+ARG PYTHON_VERSION=3.9
+ARG NUMPY_VERSION=1.22.3
+
+# wheel directory
+ENV WHEEL_DIR="${STAGING_DIR}/usr/local/share/just/wheels"
+
+# local dependencies to /usr/local
+COPY --from=library ${STAGING_DIR}/usr/local /usr/local
+
+# build wheels
+RUN mkdir -p "${WHEEL_DIR}"; \
+    # SWIG directory
+    SWIG_DIR="$(find . -type d -name 'swig' | head -n 1)"; \
+    #
+    # test for "use_2to3" in setup.py which requires older setuptools
+    # https://github.com/OSGeo/gdal/issues/4467#issuecomment-916676916
+    if grep -q 'use_2to3' "${SWIG_DIR}/python/setup.py"; then \
+        SETUPTOOLS_DEP="setuptools<58"; \
+    fi; \
+    #
+    # python flavor
+    if [[ "${PYTHON_VERSION}" == 3.7* ]]; then \
+      PYNAME='cp37-cp37m'; \
+    elif [[ "${PYTHON_VERSION}" == 3.8* ]]; then \
+      PYNAME='cp38-cp38'; \
+    elif [[ "${PYTHON_VERSION}" == 3.9* ]]; then \
+      PYNAME='cp39-cp39'; \
+    elif [[ "${PYTHON_VERSION}" == 3.10* ]]; then \
+      PYNAME='cp310-cp310'; \
+    else \
+      echo "Unrecognized PYTHON_VERSION=${PYTHON_VERSION}" >&2; \
+      exit 1; \
+    fi; \
+    PYBIN="/opt/python/${PYNAME}/bin"; \
+    #
+    # install python dependencies
+    "${PYBIN}/pip" install \
+        ${SETUPTOOLS_DEP:-} \
+        numpy==${NUMPY_VERSION}; \
+    # build wheel
+    "${PYBIN}/pip" wheel "${SWIG_DIR}/python" \
+        --no-deps --no-build-isolation -w "${WHEEL_DIR}"; \
+    #
+    # cleanup
+    rm -rf /tmp/*; \
+    ls -la "${WHEEL_DIR}";
+
+
+# -----------------------------------------------------------------------------
+# GDAL final
+# -----------------------------------------------------------------------------
+FROM base
+
+# clear /usr/local of all other packages
+RUN rm -rf /usr/local/*
+
 # migrate staging directory to /usr/local
-RUN rm -rf /usr/local; \
-    mv "${STAGING_DIR}/usr/local" /usr/local
+COPY --from=library ${STAGING_DIR}/usr/local /usr/local
+COPY --from=wheel ${STAGING_DIR}/usr/local /usr/local
+
+# Patch file for downstream image
+ENV GDAL_PATCH_FILE=/usr/local/share/just/container_build_patch/30_gdal
+ADD 30_gdal ${GDAL_PATCH_FILE}
+RUN chmod +x ${GDAL_PATCH_FILE}

--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -335,19 +335,8 @@ RUN mkdir -p "${WHEEL_DIR}"; \
     fi; \
     #
     # python flavor
-    if [[ "${PYTHON_VERSION}" == 3.7* ]]; then \
-      PYNAME='cp37-cp37m'; \
-    elif [[ "${PYTHON_VERSION}" == 3.8* ]]; then \
-      PYNAME='cp38-cp38'; \
-    elif [[ "${PYTHON_VERSION}" == 3.9* ]]; then \
-      PYNAME='cp39-cp39'; \
-    elif [[ "${PYTHON_VERSION}" == 3.10* ]]; then \
-      PYNAME='cp310-cp310'; \
-    else \
-      echo "Unrecognized PYTHON_VERSION=${PYTHON_VERSION}" >&2; \
-      exit 1; \
-    fi; \
-    PYBIN="/opt/python/${PYNAME}/bin"; \
+    PYBIN=$(ver=$(echo ${PYTHON_VERSION} | sed -E 's|(.)\.([^.]*).*|\1\2|'); \
+            echo /opt/python/cp${ver}-*/bin); \
     #
     # install python dependencies
     "${PYBIN}/pip" install \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       #   PROJ_VERSION: "${PROJ_VERSION}"
       #   GEOTIFF_VERSION: "${GEOTIFF_VERSION}"
       #   GDAL_VERSION: "${GDAL_VERSION}"
+      #   PYTHON_VERSION: "${PYTHON_VERSION}"
+      #   NUMPY_VERSION: "${NUMPY_VERSION}"
     x-no-push: 1
     image: vsiri/blueprint:gdal
 

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,11 @@
 version: '2.3'
 
+x-args:
+  GDAL_VERSION: &gdal_version "3.2.3"
+  PDAL_VERSION: &pdal_version "2.2.0"
+  PYTHON_VERSION: &python_version "3.9"
+  NUMPY_VERSION: &numpy_version "1.21.4"
+
 services:
 
   gdal:
@@ -7,7 +13,9 @@ services:
       context: ..
       dockerfile: blueprint_gdal.Dockerfile
       args:
-        GDAL_VERSION: "3.2.3"
+        GDAL_VERSION: *gdal_version
+        PYTHON_VERSION: *python_version
+        NUMPY_VERSION: *numpy_version
     image: &gdal_image vsiri/blueprint_test:gdal
 
   pdal:
@@ -16,7 +24,7 @@ services:
       dockerfile: blueprint_pdal.Dockerfile
       args:
         GDAL_IMAGE: *gdal_image
-        PDAL_VERSION: "2.2.0"
+        PDAL_VERSION: *pdal_version
     image: &pdal_image vsiri/blueprint_test:pdal
 
   test_gdal:
@@ -25,6 +33,8 @@ services:
       dockerfile: test_gdal.Dockerfile
       args:
         GDAL_IMAGE: *gdal_image
+        PYTHON_VERSION: *python_version
+        NUMPY_VERSION: *numpy_version
     image: vsiri/blueprint_test:test_gdal
 
   test_pdal:


### PR DESCRIPTION
Add GDAL python bindings to the GDAL blueprint.  This makes it easier for downstream dockers to import GDAL python bindings without the hassle of building from source.

Notes
- python bindings built for one user-specified `PYTHON_VERSION` and `NUMPY_VERSION`
- wheel stored in `usr/local/share/just/wheels`
- not a true manylinux wheel - we do not run `auditwheel`, and thus the bindings still link against installed libraries
