### PR TITLE
PDAL python bindings 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,4 +30,7 @@ services:
       #   LAZPERF_VERSION: "${LAZPERF_VERSION}"
       #   NITRO_VERSION: "${NITRO_VERSION}"
       #   PDAL_VERSION: "${PDAL_VERSION}"
+      #   PDAL_PYTHON_VERSION: "${PDAL_PYTHON_VERSION}"
+      #   PYTHON_VERSION: "${PYTHON_VERSION}"
+      #   NUMPY_VERSION: "${NUMPY_VERSION}"
     image: vsiri/blueprint:pdal

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -3,6 +3,7 @@ version: '2.3'
 x-args:
   GDAL_VERSION: &gdal_version "3.2.3"
   PDAL_VERSION: &pdal_version "2.2.0"
+  PDAL_PYTHON_VERSION: &pdal_python_version "3.0.2"
   PYTHON_VERSION: &python_version "3.9"
   NUMPY_VERSION: &numpy_version "1.21.4"
 
@@ -25,6 +26,9 @@ services:
       args:
         GDAL_IMAGE: *gdal_image
         PDAL_VERSION: *pdal_version
+        PDAL_PYTHON_VERSION: *pdal_python_version
+        PYTHON_VERSION: *python_version
+        NUMPY_VERSION: *numpy_version
     image: &pdal_image vsiri/blueprint_test:pdal
 
   test_gdal:
@@ -44,4 +48,6 @@ services:
       args:
         GDAL_IMAGE: *gdal_image
         PDAL_IMAGE: *pdal_image
+        PYTHON_VERSION: *python_version
+        NUMPY_VERSION: *numpy_version
     image: vsiri/blueprint_test:test_pdal

--- a/tests/test_pdal.Dockerfile
+++ b/tests/test_pdal.Dockerfile
@@ -1,14 +1,18 @@
 # global args
 ARG GDAL_IMAGE
 ARG PDAL_IMAGE
+ARG PYTHON_VERSION
 
 # blueprints
 FROM ${GDAL_IMAGE} as gdal
 FROM ${PDAL_IMAGE} as pdal
 
 # base image
-FROM python:3.8
+FROM python:${PYTHON_VERSION}
 SHELL ["/usr/bin/env", "bash", "-euxvc"]
+
+# build args
+ARG NUMPY_VERSION
 
 # additional runtime dependencies
 RUN apt-get update; \
@@ -20,11 +24,9 @@ RUN apt-get update; \
 COPY --from=gdal /usr/local /usr/local
 COPY --from=pdal /usr/local /usr/local
 
-# install pdal python bindings
-# PDAL is built in in a manylinux container using the old C++ ABI.
-# Ensure the pdal python wheel is built from source using the same ABI.
-# note PDAL python bindings are versioned separately from PDAL
-RUN CXXFLAGS="-D_GLIBCXX_USE_CXX11_ABI=0" pip install PDAL
-
 # Only needs to be run once for all blueprints/recipes
 RUN for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
+
+# install numpy first, then pdal from wheel
+RUN pip install numpy==${NUMPY_VERSION}; \
+    pip install /usr/local/share/just/wheels/PDAL*.whl;


### PR DESCRIPTION
Add PDAL python bindings to the PDAL blueprint. This makes it easier for downstream dockers to import PDAL  python bindings without the hassle of building from source.

Notes
- python bindings build for `PDAL_PYTHON_VERSION`, which is a separate github repo & version number from `PDAL_VERSION`
- python bindings built for one user-specified `PYTHON_VERSION` and `NUMPY_VERSION`
- wheel stored in `usr/local/share/just/wheels`
- not a true manylinux wheel - we do not run auditwheel, and thus the bindings still link against installed libraries