### PR TITLE
pyproj

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       #   PROJ_VERSION: "${PROJ_VERSION}"
       #   GEOTIFF_VERSION: "${GEOTIFF_VERSION}"
       #   GDAL_VERSION: "${GDAL_VERSION}"
+      #   PYPROJ_VERSION: "${PYPROJ_VERSION}"
       #   PYTHON_VERSION: "${PYTHON_VERSION}"
       #   NUMPY_VERSION: "${NUMPY_VERSION}"
-    x-no-push: 1
     image: vsiri/blueprint:gdal
 
   pdal:


### PR DESCRIPTION
Build `pyproj` python wheel against installed libproj.  

Additionally, use cmake to build libproj without any internal symbol renaming.