### PR TITLE
Add ulimit to fix RHEL7 bug

### DIFF
--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -130,7 +130,8 @@ FROM base as tiff
 ARG TIFF_VERSION=4.3.0
 
 # additional build dependencies
-RUN yum install -y \
+RUN ulimit -n 1024; \
+    yum install -y \
       libjpeg-turbo-devel \
       zlib-devel; \
     yum clean all
@@ -164,7 +165,8 @@ FROM base as proj
 ARG PROJ_VERSION=8.1.1
 
 # additional build dependencies
-RUN yum install -y \
+RUN ulimit -n 1024; \
+    yum install -y \
       libcurl-devel \
       libjpeg-turbo-devel \
       zlib-devel; \
@@ -208,7 +210,8 @@ FROM base as geotiff
 ARG GEOTIFF_VERSION=1.7.0
 
 # additional build dependencies
-RUN yum install -y \
+RUN ulimit -n 1024; \
+    yum install -y \
       libcurl-devel \
       libjpeg-turbo-devel \
       zlib-devel; \
@@ -249,7 +252,8 @@ ARG GDAL_VERSION=3.3.3
 ENV GDAL_VERSION=$GDAL_VERSION
 
 # additional build dependencies
-RUN yum install -y \
+RUN ulimit -n 1024; \
+    yum install -y \
       geos-devel \
       libcurl-devel \
       libjpeg-turbo-devel \

--- a/blueprint_pdal.Dockerfile
+++ b/blueprint_pdal.Dockerfile
@@ -130,7 +130,8 @@ ARG PDAL_VERSION=2.3.0
 ENV PDAL_VERSION=${PDAL_VERSION}
 
 # additional build dependencies
-RUN yum install -y \
+RUN ulimit -n 1024; \
+    yum install -y \
       geos-devel \
       libcurl-devel \
       libjpeg-turbo-devel \


### PR DESCRIPTION
RHEL tries to check all 4 billions possible FIDs due to it being old and silly. This limits it back to 1k so it's fast, old and silly