### PR TITLE
disable ECW

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,7 +105,7 @@ Build Args ``GDAL_VERSION``   Version of GDAL to download
 ..         ``NUMPY_VERSION``  Build python bindings for this numpy version
 ========== ================== ====
 
-Compiles GDAL v3, including OPENJPEG 2.4, ECW J2K 5.5, GEOS 3.11.0, libtiff 4.3, libgeotiff 1.7, PROJ v8
+Compiles GDAL v3, including OPENJPEG 2.4, GEOS 3.11.0, libtiff 4.3, libgeotiff 1.7, PROJ v8
 
 .. code-block:: Dockerfile
 


### PR DESCRIPTION
make ECW JPEG2000 decoder install optional and disable by default.  The ECW decoder is no longer easily downloadable from a static public link.