### PR TITLE
GDAL cmake

### DIFF
--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -343,7 +343,6 @@ RUN \
     mkdir build; cd build; \
     cmake .. \
         -D CMAKE_BUILD_TYPE=Release \
-        -D CMAKE_INSTALL_PREFIX="${STAGING_DIR}/usr/local" \
         -D BUILD_PYTHON_BINDINGS=OFF \
         -D GDAL_USE_PCRE=OFF \
         -D CMAKE_POLICY_DEFAULT_CMP0144=NEW \
@@ -354,7 +353,7 @@ RUN \
         -D GEOTIFF_ROOT="${STAGING_DIR}/usr/local" \
         | tee "${REPORT_DIR}/gdal_configure"; \
     cmake --build . -j$(nproc); \
-    cmake --install .; \
+    make install DESTDIR="${STAGING_DIR}"; \
     echo "${GDAL_VERSION}" > "${REPORT_DIR}/gdal_version"; \
     #
     # cleanup

--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -297,7 +297,9 @@ RUN \
 FROM base AS setup
 
 # version argument
-ARG GDAL_VERSION=3.3.3
+# note cmake build system used here was introduced in 3.5.0
+# https://github.com/OSGeo/gdal/releases/tag/v3.5.0
+ARG GDAL_VERSION=3.5.0
 ENV GDAL_VERSION=$GDAL_VERSION
 
 # additional build dependencies
@@ -330,39 +332,29 @@ COPY --from=tiff ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=proj ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=geotiff ${STAGING_DIR} ${STAGING_DIR}
 
-# local dependencies to /usr/local
-# This is necessary only for those dependencies expected to be in a "normal"
-# location. GDAL "configure" accepts direct paths for many packages, including
-# ECW and PROJ.
-COPY --from=openjpeg ${STAGING_DIR}/usr/local /usr/local
-COPY --from=geos ${STAGING_DIR}/usr/local /usr/local
-
-# add staged libraries
-ENV LD_LIBRARY_PATH="${STAGING_DIR}/usr/local/lib"
-
 # configure, build, & install
 # https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/configure
 RUN \
     # versions from file
     function get_version() { cat "${REPORT_DIR}/${1}_version" 2>/dev/null || echo ""; }; \
     ECW_VERSION=$(get_version ecw); \
-    # configure
-    ./configure \
-        --without-libtool \
-        --with-hide-internal-symbols \
-        --with-jpeg=internal \
-        --with-png=internal \
-        --with-pcre=no \
-        --with-libtiff="${STAGING_DIR}/usr/local" \
-        --with-geotiff="${STAGING_DIR}/usr/local" \
-        --with-openjpeg \
-        --with-proj="${STAGING_DIR}/usr/local" \
-        ${ECW_VERSION:+--with-ecw="${STAGING_DIR}/usr/local/ecw"} \
-        | tee "${REPORT_DIR}/gdal_configure"; \
     #
-    # build & install
-    make -j "$(nproc)"; \
-    make install "DESTDIR=${STAGING_DIR}"; \
+    # configure, build, & install
+    mkdir build; cd build; \
+    cmake .. \
+        -D CMAKE_BUILD_TYPE=Release \
+        -D CMAKE_INSTALL_PREFIX="${STAGING_DIR}/usr/local" \
+        -D BUILD_PYTHON_BINDINGS=OFF \
+        -D GDAL_USE_PCRE=OFF \
+        -D CMAKE_POLICY_DEFAULT_CMP0144=NEW \
+        -D OPENJPEG_ROOT="${STAGING_DIR}/usr/local" \
+        ${ECW_VERSION:+-D ECW_ROOT="${STAGING_DIR}/usr/local/ecw"} \
+        -D TIFF_ROOT="${STAGING_DIR}/usr/local" \
+        -D PROJ_ROOT="${STAGING_DIR}/usr/local" \
+        -D GEOTIFF_ROOT="${STAGING_DIR}/usr/local" \
+        | tee "${REPORT_DIR}/gdal_configure"; \
+    cmake --build . -j$(nproc); \
+    cmake --install .; \
     echo "${GDAL_VERSION}" > "${REPORT_DIR}/gdal_version"; \
     #
     # cleanup

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,5 @@
 x-args:
-  GDAL_VERSION: &gdal_version "3.2.3"
+  GDAL_VERSION: &gdal_version "3.5.2"
   PDAL_VERSION: &pdal_version "2.2.0"
   PDAL_PYTHON_VERSION: &pdal_python_version "3.0.2"
   PYTHON_VERSION: &python_version "3.9"

--- a/tests/test-gdal.bsh
+++ b/tests/test-gdal.bsh
@@ -19,11 +19,11 @@ begin_test "GDAL"
 
   # command line GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
-  [ "${RESULT}" = 'GDAL 3.2.3, released 2021/04/27' ]
+  [ "${RESULT}" = 'GDAL 3.5.2, released 2022/09/02' ]
 
   # python GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal; print(gdal.__version__)')"
-  [ "${RESULT}" = '3.2.3' ]
+  [ "${RESULT}" = '3.5.2' ]
 
   # test python import (for example, gdal_array may fail to import if numpy is not installed)
   docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal, ogr, osr, gdal_array, gdalconst'

--- a/tests/test-pdal.bsh
+++ b/tests/test-pdal.bsh
@@ -26,10 +26,10 @@ begin_test "PDAL"
   [ "${RESULT}" = '2.2.0' ]
 
   # command line GDAL version
-  # Note this version is purposefully different from the default recipe_gdal
-  # GDAL_VERSION to ensure the chained recipes honor all version ARGs
+  # Note this version is purposefully different from the default blueprint_gdal
+  # GDAL_VERSION to ensure the chained blueprints honor all version ARGs
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
-  [ "${RESULT}" = 'GDAL 3.2.3, released 2021/04/27' ]
+  [ "${RESULT}" = 'GDAL 3.5.2, released 2022/09/02' ]
 
 )
 end_test

--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -12,16 +12,11 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 # local args
 ARG NUMPY_VERSION
 
-# additional runtime dependencies
-RUN apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgeos-c1v5; \
-    rm -r /var/lib/apt/lists/*
-
 # copy from blueprints
 COPY --from=gdal /usr/local /usr/local
 
 # Only needs to be run once for all blueprints/recipes
+ENV LD_LIBRARY_PATH="/usr/local/lib64"
 RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
 # install numpy then GDAL python bindings

--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -15,8 +15,10 @@ ARG NUMPY_VERSION
 # copy from blueprints
 COPY --from=gdal /usr/local /usr/local
 
-# Only needs to be run once for all blueprints/recipes
+# access to lib64 packages
 ENV LD_LIBRARY_PATH="/usr/local/lib64"
+
+# Only needs to be run once for all blueprints/recipes
 RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
 # install numpy then GDAL python bindings

--- a/tests/test_pdal.Dockerfile
+++ b/tests/test_pdal.Dockerfile
@@ -18,8 +18,10 @@ ARG NUMPY_VERSION
 COPY --from=gdal /usr/local /usr/local
 COPY --from=pdal /usr/local /usr/local
 
-# Only needs to be run once for all blueprints/recipes
+# access to lib64 packages
 ENV LD_LIBRARY_PATH="/usr/local/lib64"
+
+# Only needs to be run once for all blueprints/recipes
 RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
 # install numpy first, then pdal from wheel

--- a/tests/test_pdal.Dockerfile
+++ b/tests/test_pdal.Dockerfile
@@ -14,17 +14,12 @@ SHELL ["/usr/bin/env", "bash", "-euxvc"]
 # build args
 ARG NUMPY_VERSION
 
-# additional runtime dependencies
-RUN apt-get update; \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        libgeos-c1v5; \
-    rm -r /var/lib/apt/lists/*
-
 # copy from blueprints
 COPY --from=gdal /usr/local /usr/local
 COPY --from=pdal /usr/local /usr/local
 
 # Only needs to be run once for all blueprints/recipes
+ENV LD_LIBRARY_PATH="/usr/local/lib64"
 RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
 # install numpy first, then pdal from wheel


### PR DESCRIPTION
Migrate to GDAL cmake build system used in v3.5+
https://github.com/OSGeo/gdal/releases/tag/v3.5.0