### PR TITLE
GDAL/PDAL updates

### DIFF
--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -158,11 +158,11 @@ RUN \
     mkdir build; cd build; \
     cmake .. \
         -DCMAKE_BUILD_TYPE=Release \
-        -DCMAKE_INSTALL_PREFIX="${STAGING_DIR}/usr/local" \
         -DBUILD_DOCUMENTATION=OFF \
+        -DBUILD_TESTING=OFF \
         | tee "${REPORT_DIR}/geos_configure"; \
     cmake --build . -j$(nproc); \
-    cmake --install .; \
+    make install DESTDIR="${STAGING_DIR}"; \
     echo "${GEOS_VERSION}" > "${REPORT_DIR}/geos_version"; \
     #
     # cleanup
@@ -234,7 +234,6 @@ RUN \
     # configure, build, & install
     mkdir build; cd build; \
     cmake .. \
-        -DCMAKE_INSTALL_PREFIX="${STAGING_DIR}/usr/local" \
         -DCMAKE_INSTALL_LIBDIR="lib" \
         -DBUILD_SHARED_LIBS=ON \
         -DCMAKE_BUILD_TYPE=Release \
@@ -242,7 +241,7 @@ RUN \
         -DBUILD_TESTING:BOOL=OFF \
         | tee "${REPORT_DIR}/proj_configure"; \
     cmake --build . -j$(nproc); \
-    cmake --install .; \
+    make install DESTDIR="${STAGING_DIR}"; \
     echo "${PROJ_VERSION}" > "${REPORT_DIR}/proj_version"; \
     #
     # cleanup
@@ -331,6 +330,10 @@ COPY --from=geos ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=tiff ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=proj ${STAGING_DIR} ${STAGING_DIR}
 COPY --from=geotiff ${STAGING_DIR} ${STAGING_DIR}
+
+# GDAL FindGEOS.cmake requires GEOS at its final /usr/local location
+# https://github.com/OSGeo/gdal/blob/master/cmake/modules/packages/FindGEOS.cmake
+COPY --from=geos ${STAGING_DIR}/usr/local /usr/local
 
 # configure, build, & install
 # https://raw.githubusercontent.com/OSGeo/gdal/master/gdal/configure

--- a/blueprint_gdal.Dockerfile
+++ b/blueprint_gdal.Dockerfile
@@ -1,7 +1,7 @@
-# CentOS 7 with GDAL 3+
+# CentOS 7 with GDAL 3.5+
 # - includes OPENJPEG 2.4, ECW J2K 5.5, libtiff4.3, libgeotiff 1.7, PROJ v8
 # - compatible with pypi GDAL bindings (recipe does not build python bindings)
-# - recipe is not currently compatible with GDAL 2.
+# - recipe is only compatible with GDAL 3.5+ using the cmake build system
 #
 # This dockerfile follows procedures from the offical GDAL dockers
 #   https://github.com/OSGeo/gdal/tree/master/gdal/docker
@@ -378,14 +378,6 @@ COPY --from=library ${STAGING_DIR}/usr/local /usr/local
 
 # build wheels
 RUN mkdir -p "${WHEEL_DIR}"; \
-    # SWIG directory
-    SWIG_DIR="$(find . -type d -name 'swig' | head -n 1)"; \
-    #
-    # test for "use_2to3" in setup.py which requires older setuptools
-    # https://github.com/OSGeo/gdal/issues/4467#issuecomment-916676916
-    if grep -q 'use_2to3' "${SWIG_DIR}/python/setup.py"; then \
-        SETUPTOOLS_DEP="setuptools<58"; \
-    fi; \
     #
     # python flavor
     PYBIN=$(ver=$(echo ${PYTHON_VERSION} | sed -E 's|(.)\.([^.]*).*|\1\2|'); \
@@ -395,12 +387,11 @@ RUN mkdir -p "${WHEEL_DIR}"; \
     # Note pyproj incompatibility with cython 3+
     # https://github.com/pyproj4/pyproj/issues/1321
     "${PYBIN}/pip" install \
-        ${SETUPTOOLS_DEP:-} \
         "cython<3" \
         numpy==${NUMPY_VERSION}; \
     #
     # build gdal wheel
-    "${PYBIN}/pip" wheel "${SWIG_DIR}/python" \
+    "${PYBIN}/pip" wheel gdal==${GDAL_VERSION} --no-binary gdal \
         --no-deps --no-build-isolation -w "${WHEEL_DIR}"; \
     #
     # build pyproj wheel

--- a/blueprint_pdal.Dockerfile
+++ b/blueprint_pdal.Dockerfile
@@ -220,7 +220,9 @@ RUN mkdir -p "${WHEEL_DIR}"; \
         ninja \
         numpy==${NUMPY_VERSION} \
         pybind11[global] \
-        scikit-build; \
+        scikit-build \
+        scikit-build-core \
+        ; \
     #
     # build wheel
     # Note $PYBIN is added to the path to allow cmake (used during the build

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,5 +1,5 @@
 x-args:
-  GDAL_VERSION: &gdal_version "3.5.2"
+  GDAL_VERSION: &gdal_version "3.6.4"
   PDAL_VERSION: &pdal_version "2.2.0"
   PDAL_PYTHON_VERSION: &pdal_python_version "3.0.2"
   PYTHON_VERSION: &python_version "3.9"

--- a/tests/test-gdal.bsh
+++ b/tests/test-gdal.bsh
@@ -19,11 +19,11 @@ begin_test "GDAL"
 
   # command line GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
-  [ "${RESULT}" = 'GDAL 3.5.2, released 2022/09/02' ]
+  [ "${RESULT}" = 'GDAL 3.6.4, released 2023/04/17' ]
 
   # python GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal; print(gdal.__version__)')"
-  [ "${RESULT}" = '3.5.2' ]
+  [ "${RESULT}" = '3.6.4' ]
 
   # test python import (for example, gdal_array may fail to import if numpy is not installed)
   docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal, ogr, osr, gdal_array, gdalconst'

--- a/tests/test-gdal.bsh
+++ b/tests/test-gdal.bsh
@@ -28,5 +28,14 @@ begin_test "GDAL"
   # test python import (for example, gdal_array may fail to import if numpy is not installed)
   docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal, ogr, osr, gdal_array, gdalconst'
 
+  # test for expected LDD results
+  RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'ldd /usr/local/lib64/libgdal.so | grep /usr/local')"
+  [[ ${RESULT} == */usr/local/lib64/libgeos.so* ]]
+  [[ ${RESULT} == */usr/local/lib64/libgeos_c.so* ]]
+  [[ ${RESULT} == */usr/local/lib/libgeotiff.so* ]]
+  [[ ${RESULT} == */usr/local/lib/libopenjp2.so* ]]
+  [[ ${RESULT} == */usr/local/lib/libproj.so* ]]
+  [[ ${RESULT} == */usr/local/lib/libtiff.so* ]]
+
 )
 end_test

--- a/tests/test-pdal.bsh
+++ b/tests/test-pdal.bsh
@@ -29,7 +29,7 @@ begin_test "PDAL"
   # Note this version is purposefully different from the default blueprint_gdal
   # GDAL_VERSION to ensure the chained blueprints honor all version ARGs
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
-  [ "${RESULT}" = 'GDAL 3.5.2, released 2022/09/02' ]
+  [ "${RESULT}" = 'GDAL 3.6.4, released 2023/04/17' ]
 
 )
 end_test


### PR DESCRIPTION
- `blueprint_gdal`
  - simplify gdal python wheel. `use_2to3` check is no longer needed as the blueprint is only for GDAL 3.5+.
  - do not build geos tests
  - prefer `make install DESTDIR` to place libraries in `STAGING_DIR` for all dependencies using cmake.  This ensures applications like `geos-config` return the expected install location.
- `blueprint_pdal`
    - Add `scikit-build-core` to build environment for newer pdal versions
- tests
  - Update tests to use GDAL 3.6.4
  - Add `ldd` tests to check for expected `libgdal.so` dependencies
