### PR TITLE
GDAL/PDAL manylinux_2_28_x86_64

### DIFF
--- a/tests/test-gdal.bsh
+++ b/tests/test-gdal.bsh
@@ -18,6 +18,14 @@ begin_test "GDAL"
 
   DOCKER_IMAGE="vsiri/blueprint_test:test_gdal"
 
+  # PROJ version
+  RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'proj 2>&1')"
+  assert_sub_str "${RESULT}" "Rel. 9.4.1, June 1st, 2024"
+
+  # pyproj version
+  RESULT="$(docker run --rm ${DOCKER_IMAGE} python -c 'import pyproj; print(pyproj.__version__)')"
+  assert_str_eq "${RESULT}" "3.7.0"
+
   # command line GDAL version
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'gdalinfo --version')"
   assert_str_eq "${RESULT}" "GDAL 3.10.3, released 2025/04/01"
@@ -29,13 +37,19 @@ begin_test "GDAL"
   # test python import (for example, gdal_array may fail to import if numpy is not installed)
   docker run --rm ${DOCKER_IMAGE} python -c 'from osgeo import gdal, ogr, osr, gdal_array, gdalconst'
 
-  # test for expected LDD results
+  # test for expected `ldd libproj.so` results
+  RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'ldd /usr/local/lib/libproj.so | grep /usr/local')"
+  assert_sub_str "${RESULT}" "libsqlite3.so"
+  assert_sub_str "${RESULT}" "libtiff.so"
+
+  # test for expected `ldd libgdal.so` results
   RESULT="$(docker run --rm ${DOCKER_IMAGE} bash -c 'ldd /usr/local/lib64/libgdal.so | grep /usr/local')"
   assert_sub_str "${RESULT}" "libgeos.so"
   assert_sub_str "${RESULT}" "libgeos_c.so"
   assert_sub_str "${RESULT}" "libgeotiff.so"
   assert_sub_str "${RESULT}" "libopenjp2.so"
   assert_sub_str "${RESULT}" "libproj.so"
+  assert_sub_str "${RESULT}" "libsqlite3.so"
   assert_sub_str "${RESULT}" "libtiff.so"
 
 )

--- a/tests/test_gdal.Dockerfile
+++ b/tests/test_gdal.Dockerfile
@@ -21,6 +21,6 @@ ENV LD_LIBRARY_PATH="/usr/local/lib64"
 # Only needs to be run once for all blueprints/recipes
 RUN shopt -s nullglob; for patch in /usr/local/share/just/container_build_patch/*; do "${patch}"; done
 
-# install numpy then GDAL python bindings
+# install numpy then python bindings
 RUN pip install numpy==${NUMPY_VERSION}; \
-    pip install /usr/local/share/just/wheels/GDAL*.whl
+    pip install /usr/local/share/just/wheels/*.whl


### PR DESCRIPTION
Update GDAL and PDAL recipes to use `manylinux_2_28_x86_64:2025.09.28-1` based on Alma Linux.  Generally minor modifications to use the new manylinux image.  
https://github.com/pypa/manylinux?tab=readme-ov-file#manylinux_2_28-almalinux-8-based

The biggest change is with respect to sqlite3 for the GDAL blueprint. manylinux includes a relatively new version of sqlite3 in the container.  However, the sqlite3 project decided to remove the SONAME from `libsqlite3.so` by default, leaving SONAME details to packagers.
https://github.com/sqlite/sqlite/blob/version-3.50.4/autosetup/sqlite-config.tcl#L339-L346

manylinux did not add an SONAME to their internally built `libsqlite3.so`.  Without an SONAME, dependent projects like `libproj.so` report an absolute file path for `libsqlite3.so` and are no longer portable. We thus add the legacy SONAME back to `libsqlite3.so` via `patchelf`, and include the adjusted sqlite3 package in GDAL blueprint outputs.